### PR TITLE
Fix ToStringCall cast detection

### DIFF
--- a/src/main/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspection.kt
+++ b/src/main/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallInspection.kt
@@ -25,6 +25,13 @@ class ToStringCallInspection : PhpCleanInspection() {
         return object : PhpElementVisitor() {
             override fun visitPhpVariable(variable: Variable) {
                 if (context.match(variable.parent)) {
+                    if (variable.parent is UnaryExpression) {
+                        val unary = variable.parent as UnaryExpression
+                        val parent = unary.parent
+                        if (parent is MethodReference && parent.classReference == unary) {
+                            return
+                        }
+                    }
                     if (IsSingleClassType().match(variable)) {
                         holder.registerProblem(
                                 variable,
@@ -51,6 +58,9 @@ class ToStringCallInspection : PhpCleanInspection() {
             }
 
             override fun visitPhpMethodReference(reference: MethodReference) {
+                if (reference.parent is UnaryExpression && reference.classReference is Variable) {
+                    return
+                }
                 if (context.match(reference.parent)) {
                     val resolve = reference.resolve()
                     if (resolve is Function && resolve.name != "__toString") {

--- a/src/test/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallIssue212Test.kt
+++ b/src/test/kotlin/com/funivan/idea/phpClean/inspections/toStringCall/ToStringCallIssue212Test.kt
@@ -1,0 +1,31 @@
+package com.funivan.idea.phpClean.inspections.toStringCall
+
+import com.funivan.idea.phpClean.BaseInspectionTest
+import kotlin.test.Test
+
+class ToStringCallIssue212Test : BaseInspectionTest() {
+    @Test
+    fun testCastFunctionCallFromObject() {
+        assert(
+            ToStringCallInspection(),
+            """
+                    <?php
+                    class BlaFoo {
+                        public function __toString(): string {
+                            return 'BlaFoo';
+                        }
+                    }
+                    class Another {
+                        public function returnsBlaFoo(): BlaFoo {
+                            return new BlaFoo();
+                        }
+                        public function __toString(): string {
+                            return '';
+                        }
+                    }
+                    ${'$'}another = new Another();
+                    (string)${'$'}another->returnsBlaFoo();
+                    """
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- handle variables cast before method calls
- restore expected warning for casting chained call result

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686d2187c808832884e9982e329d2f1c