### PR TITLE
Fix offline build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -121,6 +121,11 @@ tasks {
     named("runIde") {
         dependsOn("copyInspections")
     }
+
+    // Network-sensitive tasks: run ONLY when not offline
+    matching { name in listOf("publishPlugin", "runPluginVerifier") }.configureEach {
+        onlyIf { !gradle.startParameter.isOffline }
+    }
 }
 tasks.getByName("buildSearchableOptions").onlyIf { false }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -122,7 +122,9 @@ tasks {
         dependsOn("copyInspections")
     }
 
-    // Network-sensitive tasks: run ONLY when not offline
+    // Network-sensitive tasks: run ONLY when not in --offline mode
+    // You'll probaly need to prime your caches during an online phase, using a command such as:
+    // ./gradlew help --refresh-dependencies --no-daemon
     matching { name in listOf("publishPlugin", "runPluginVerifier") }.configureEach {
         onlyIf { !gradle.startParameter.isOffline }
     }


### PR DESCRIPTION
## Summary
- skip `publishPlugin` and `runPluginVerifier` when Gradle is offline

## Testing
- `./gradlew test --offline`

------
https://chatgpt.com/codex/tasks/task_e_686ddb5ff2748328bdaea12a82135d93